### PR TITLE
TypeError in SinglePeriodOpt.get_trades() when solver fails silently

### DIFF
--- a/cvxportfolio/policies.py
+++ b/cvxportfolio/policies.py
@@ -293,7 +293,7 @@ class SinglePeriodOpt(BasePolicy):
                 return self._nulltrade(portfolio)
 
             return pd.Series(index=portfolio.index, data=(z.value * value))
-        except cvx.SolverError:
+        except (cvx.SolverError, TypeError):
             logging.error(
                 'The solver %s failed. Defaulting to no trades' % self.solver)
             return self._nulltrade(portfolio)


### PR DESCRIPTION
Sometimes z.value is None and you get the following error:
  File "/home/dev/portfolio_optimizer/scripts/my_port.py", line 343, in optimize_with_mi
    trades = spo_policy.get_trades(init_portfolio)
  File "/home/anaconda3/envs/lib/python3.6/site-packages/cvxportfolio/policies.py", line 293, in get_trades
    return pd.Series(index=portfolio.index, data=(z.value * value))
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'