### PR TITLE
Added weight_expr function to MultipleReturnsForecasts class. Removed…

### DIFF
--- a/cvxportfolio/policies.py
+++ b/cvxportfolio/policies.py
@@ -333,7 +333,6 @@ class MultiPeriodOpt(SinglePeriodOpt):
         super(MultiPeriodOpt, self).__init__(*args, **kwargs)
 
     def get_trades(self, portfolio, t=pd.datetime.today()):
-
         value = sum(portfolio)
         assert (value > 0.)
         w = cvx.Constant(portfolio.values / value)
@@ -350,7 +349,9 @@ class MultiPeriodOpt(SinglePeriodOpt):
             # range(self.lookahead_periods)]:
 
             #            tau = t + delta_t
-            z = cvx.Variable(*w.size)
+            #z = cvx.Variable(*w.size)
+            z = cvx.Variable(w.size)
+
             wplus = w + z
             obj = self.return_forecast.weight_expr_ahead(t, tau, wplus)
 

--- a/cvxportfolio/policies.py
+++ b/cvxportfolio/policies.py
@@ -347,7 +347,7 @@ class MultiPeriodOpt(SinglePeriodOpt):
                 self.trading_times[self.trading_times.index(t):
                                    self.trading_times.index(t) +
                                    self.lookahead_periods]:
-            
+
             # z = cvx.Variable(*w.size)
             z = cvx.Variable(w.size)
 

--- a/cvxportfolio/policies.py
+++ b/cvxportfolio/policies.py
@@ -334,7 +334,7 @@ class MultiPeriodOpt(SinglePeriodOpt):
 
     def get_trades(self, portfolio, t=pd.datetime.today()):
         value = sum(portfolio)
-        print("Getting trades at : ", t)
+        # print("Getting trades at : ", t)
 
         assert (value > 0.)
         w = cvx.Constant(portfolio.values / value)

--- a/cvxportfolio/policies.py
+++ b/cvxportfolio/policies.py
@@ -334,6 +334,8 @@ class MultiPeriodOpt(SinglePeriodOpt):
 
     def get_trades(self, portfolio, t=pd.datetime.today()):
         value = sum(portfolio)
+        print("Getting trades at : ", t)
+
         assert (value > 0.)
         w = cvx.Constant(portfolio.values / value)
 
@@ -345,11 +347,8 @@ class MultiPeriodOpt(SinglePeriodOpt):
                 self.trading_times[self.trading_times.index(t):
                                    self.trading_times.index(t) +
                                    self.lookahead_periods]:
-            # delta_t in [pd.Timedelta('%d days' % i) for i in
-            # range(self.lookahead_periods)]:
-
-            #            tau = t + delta_t
-            #z = cvx.Variable(*w.size)
+            
+            # z = cvx.Variable(*w.size)
             z = cvx.Variable(w.size)
 
             wplus = w + z

--- a/cvxportfolio/result.py
+++ b/cvxportfolio/result.py
@@ -176,7 +176,7 @@ class SimulationResult():
 
     @property
     def annual_growth_rate(self):
-        """The annualized growth rate PPY/T \sum_{t=1}^T log(v_{t+1}/v_t)
+        """The annualized growth rate PPY/T sum_{t=1}^T log(v_{t+1}/v_t)
         """
         return self.growth_rates.sum() * self.PPY / self.growth_rates.size
 

--- a/cvxportfolio/returns.py
+++ b/cvxportfolio/returns.py
@@ -89,6 +89,18 @@ class MPOReturnsForecast(BaseReturnsModel):
     def __init__(self, alpha_data):
         self.alpha_data = alpha_data
 
+    def weight_expr(self, t, wplus):
+        """Returns the estimate at time t of alpha at time t.
+
+        Args:
+          t: time estimate is made.
+          wplus: An expression for holdings.
+
+        Returns:
+          An expression for the alpha.
+        """
+        return self.alpha_data[(t, t)].values.T * wplus
+
     def weight_expr_ahead(self, t, tau, wplus):
         """Returns the estimate at time t of alpha at time tau.
 


### PR DESCRIPTION
… * from definition of control variable in MultiPeriodOpt.get_trades because was not working before and this quantity will never be of variable number (always a single tuple).

These changes were necessary in order to get the multiperiod optimization example notebook to run.