### PR TITLE
Pandas 1.0.x Compatibility

### DIFF
--- a/cvxportfolio/simulator.py
+++ b/cvxportfolio/simulator.py
@@ -243,8 +243,8 @@ class MarketSimulator():
         data = pd.DataFrame(columns=[s.name for s in alpha_sources],
                             index=attr_times,
                             data=Pmat.value.T * wmask)
-        data['residual'] = true_arr - np.matrix((weights * Pmat).value).A1
-        data['RMS error'] = np.matrix(
-            cvx.norm(Wmat * Pmat - Rmat, 2, axis=0).value).A1
+        data['residual'] = true_arr - np.asarray((weights * Pmat).value).ravel()
+        data['RMS error'] = np.asarray(
+            cvx.norm(Wmat * Pmat - Rmat, 2, axis=0).value).ravel()
         data['RMS error'] /= np.sqrt(num_sources)
         return data

--- a/cvxportfolio/tests/test_optimizer.py
+++ b/cvxportfolio/tests/test_optimizer.py
@@ -50,7 +50,7 @@ class TestOptimizer(BaseTest):
         gamma = 100.
         n = len(self.universe)
         alpha_model = ReturnsForecast(self.returns)
-        emp_Sigma = np.cov(self.returns.as_matrix().T) + np.eye(n)*1e-3
+        emp_Sigma = np.cov(self.returns.values.T) + np.eye(n)*1e-3
         risk_model = FullSigma(emp_Sigma)
         tcost_model = TcostModel(0, self.b, self.sigma, self.volume, power=2)
         hcost_model = HcostModel(self.s*0, self.s)

--- a/cvxportfolio/tests/test_simulator.py
+++ b/cvxportfolio/tests/test_simulator.py
@@ -117,5 +117,5 @@ class TestSimulator(BaseTest):
         results.log_simulation(t=t, u=u, h_next=h_next,
                                risk_free_return=0.,
                                exec_time=0)
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             results.simulator_HcostModel.sum().sum(), 2800.0)

--- a/cvxportfolio/tests/test_what_if.py
+++ b/cvxportfolio/tests/test_what_if.py
@@ -49,7 +49,7 @@ class TestWhatIf(BaseTest):
             self.returns, name=i) for i in range(3)]
         weights = np.array([0.1, 0.3, 0.6])
         alpha_model = MultipleReturnsForecasts(alpha_sources, weights)
-        emp_Sigma = np.cov(self.returns.as_matrix().T)
+        emp_Sigma = np.cov(self.returns.values.T)
         risk_model = FullSigma(emp_Sigma, gamma=100.)
         tcost_model = TcostModel(self.volume, self.sigma, self.a, self.b)
         hcost_model = HcostModel(self.s, self.s*0)
@@ -101,7 +101,7 @@ class TestWhatIf(BaseTest):
             self.returns, name=i) for i in range(3)]
         weights = np.array([0.1, 0.3, 0.6])
         alpha_model = MultipleReturnsForecasts(alpha_sources, weights)
-        emp_Sigma = np.cov(self.returns.as_matrix().T)
+        emp_Sigma = np.cov(self.returns.values.T)
         risk_model = FullSigma(emp_Sigma, gamma=100.)
         tcost_model = TcostModel(self.a, self.b, self.sigma, self.volume)
         hcost_model = HcostModel(self.s, self.s*0)
@@ -157,7 +157,7 @@ class TestWhatIf(BaseTest):
             self.returns, name=i) for i in range(3)]
         weights = np.array([0.1, 0.3, 0.6])
         alpha_model = MultipleReturnsForecasts(alpha_sources, weights)
-        emp_Sigma = np.cov(self.returns.as_matrix().T)
+        emp_Sigma = np.cov(self.returns.values.T)
         risk_model = FullSigma(emp_Sigma)
         tcost_model = TcostModel(self.a, self.b, self.sigma, self.volume)
         hcost_model = HcostModel(self.s)


### PR DESCRIPTION
* replace deprecated `pandas.datetime` by `datetime.datetime`
* replace deprecated np.matrix, i.e. `.as_matrix` by `values`, replace `np.matrix.A1` by `np.asarray.ravel`
* replace deprecated alias `assertAlmostEquals` by `assertAlmostEqual