### PR TITLE
Pandas 1.0.x compatibility

### DIFF
--- a/cvxportfolio/policies.py
+++ b/cvxportfolio/policies.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from abc import ABCMeta, abstractmethod
+import datetime as dt
 import pandas as pd
 import numpy as np
 import logging
@@ -39,7 +40,7 @@ class BasePolicy(object, metaclass=ABCMeta):
         self.constraints = []
 
     @abstractmethod
-    def get_trades(self, portfolio, t=pd.datetime.today()):
+    def get_trades(self, portfolio, t=dt.datetime.today()):
         """Trades list given current portfolio and time t.
         """
         return NotImplemented
@@ -57,7 +58,7 @@ class Hold(BasePolicy):
     """Hold initial portfolio.
     """
 
-    def get_trades(self, portfolio, t=pd.datetime.today()):
+    def get_trades(self, portfolio, t=dt.datetime.today()):
         return self._nulltrade(portfolio)
 
 
@@ -71,7 +72,7 @@ class RankAndLongShort(BasePolicy):
         self.return_forecast = return_forecast
         super(RankAndLongShort, self).__init__()
 
-    def get_trades(self, portfolio, t=pd.datetime.today()):
+    def get_trades(self, portfolio, t=dt.datetime.today()):
         prediction = values_in_time(self.return_forecast, t)
         sorted_ret = prediction.sort_values()
 
@@ -104,7 +105,7 @@ class ProportionalTrade(BasePolicy):
         self.time_steps = time_steps
         super(ProportionalTrade, self).__init__()
 
-    def get_trades(self, portfolio, t=pd.datetime.today()):
+    def get_trades(self, portfolio, t=dt.datetime.today()):
         try:
             missing_time_steps = len(
                 self.time_steps) - next(i for (i, x)
@@ -120,7 +121,7 @@ class ProportionalTrade(BasePolicy):
 class SellAll(BasePolicy):
     """Sell all non-cash assets."""
 
-    def get_trades(self, portfolio, t=pd.datetime.today()):
+    def get_trades(self, portfolio, t=dt.datetime.today()):
         trade = -pd.Series(portfolio, copy=True)
         trade.ix[-1] = 0.
         return trade
@@ -142,7 +143,7 @@ class FixedTrade(BasePolicy):
         assert(self.tradeweight is None or sum(self.tradeweight) == 0.)
         super(FixedTrade, self).__init__()
 
-    def get_trades(self, portfolio, t=pd.datetime.today()):
+    def get_trades(self, portfolio, t=dt.datetime.today()):
         if self.tradevec is not None:
             return self.tradevec
         return sum(portfolio) * self.tradeweight
@@ -179,7 +180,7 @@ class PeriodicRebalance(BaseRebalance):
         self.last_t = t
         return result
 
-    def get_trades(self, portfolio, t=pd.datetime.today()):
+    def get_trades(self, portfolio, t=dt.datetime.today()):
         return self._rebalance(portfolio) if self.is_start_period(t) else \
             self._nulltrade(portfolio)
 
@@ -193,7 +194,7 @@ class AdaptiveRebalance(BaseRebalance):
         self.tracking_error = tracking_error
         super(AdaptiveRebalance, self).__init__()
 
-    def get_trades(self, portfolio, t=pd.datetime.today()):
+    def get_trades(self, portfolio, t=dt.datetime.today()):
         weights = portfolio / sum(portfolio)
         diff = (weights - self.target).values
 
@@ -243,7 +244,7 @@ class SinglePeriodOpt(BasePolicy):
         """
 
         if t is None:
-            t = pd.datetime.today()
+            t = dt.datetime.today()
 
         value = sum(portfolio)
         w = portfolio / value
@@ -331,7 +332,7 @@ class MultiPeriodOpt(SinglePeriodOpt):
         self.terminal_weights = terminal_weights
         super(MultiPeriodOpt, self).__init__(*args, **kwargs)
 
-    def get_trades(self, portfolio, t=pd.datetime.today()):
+    def get_trades(self, portfolio, t=dt.datetime.today()):
 
         value = sum(portfolio)
         assert (value > 0.)

--- a/cvxportfolio/simulator.py
+++ b/cvxportfolio/simulator.py
@@ -243,8 +243,8 @@ class MarketSimulator():
         data = pd.DataFrame(columns=[s.name for s in alpha_sources],
                             index=attr_times,
                             data=Pmat.value.T * wmask)
-        data['residual'] = true_arr - np.matrix((weights * Pmat).value).A1
-        data['RMS error'] = np.matrix(
-            cvx.norm(Wmat * Pmat - Rmat, 2, axis=0).value).A1
+        data['residual'] = true_arr - np.asarray((weights * Pmat).value).ravel()
+        data['RMS error'] = np.asarray(
+            cvx.norm(Wmat * Pmat - Rmat, 2, axis=0).value).ravel()
         data['RMS error'] /= np.sqrt(num_sources)
         return data

--- a/cvxportfolio/utils.py
+++ b/cvxportfolio/utils.py
@@ -79,8 +79,7 @@ def plot_what_if(time, true_results, alt_results):
 
 def null_checker(obj):
     """Check if obj contains NaN."""
-    if (isinstance(obj, pd.Panel) or
-        isinstance(obj, pd.DataFrame) or
+    if (isinstance(obj, pd.DataFrame) or
             isinstance(obj, pd.Series)):
         if np.any(pd.isnull(obj)):
             raise ValueError('Data object contains NaN values', obj)


### PR DESCRIPTION
* Fix FutureWarning: the `pandas.datetime` class is now deprecated. Import from `datetime` instead
* Drop pd.Panel per TODOs
* Fix FutureWarning: it is no longer recommended to use np.matrix, even for linear algebra. Instead use regular arrays. The class may be removed in the future.