### PR TITLE
Fix matrix multiplication warning

### DIFF
--- a/cvxportfolio/risks.py
+++ b/cvxportfolio/risks.py
@@ -157,7 +157,7 @@ class FactorModelSigma(BaseRiskModel):
     def _estimate(self, t, wplus, z, value):
         self.expression = cvx.sum_squares(cvx.multiply(
             np.sqrt(values_in_time(self.idiosync, t)), wplus)) + \
-            cvx.quad_form((wplus.T * values_in_time(self.exposures, t).values.T).T,
+            cvx.quad_form((wplus.T @ values_in_time(self.exposures, t).values.T).T,
                           values_in_time(self.factor_Sigma, t).values)
         return self.expression
 


### PR DESCRIPTION
Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
    Use ``*`` for matrix-scalar and vector-scalar multiplication.
    Use ``@`` for matrix-matrix and matrix-vector multiplication.
    Use ``multiply`` for elementwise multiplication.

Update FactorModelSigma to be compatible with latest CVXPY and avoid above warnings