### PR TITLE
Fix all matrix multiplication warnings

### DIFF
--- a/cvxportfolio/constraints.py
+++ b/cvxportfolio/constraints.py
@@ -209,7 +209,7 @@ class FactorMaxLimit(BaseConstraint):
             t: time
             w_plus: holdings
         """
-        return values_in_time(self.factor_exposure, t).T * w_plus[:-1] <= \
+        return values_in_time(self.factor_exposure, t).T @ w_plus[:-1] <= \
             values_in_time(self.limit, t)
 
 
@@ -234,7 +234,7 @@ class FactorMinLimit(BaseConstraint):
             t: time
             w_plus: holdings
         """
-        return values_in_time(self.factor_exposure, t).T * w_plus[:-1] >= \
+        return values_in_time(self.factor_exposure, t).T @ w_plus[:-1] >= \
             values_in_time(self.limit, t)
 
 
@@ -253,5 +253,5 @@ class FixedAlpha(BaseConstraint):
         self.alpha_target = alpha_target
 
     def _weight_expr(self, t, w_plus, z, v):
-        return values_in_time(self.return_forecast, t).T * w_plus[:-1] == \
+        return values_in_time(self.return_forecast, t).T @ w_plus[:-1] == \
             values_in_time(self.alpha_target, t)

--- a/cvxportfolio/simulator.py
+++ b/cvxportfolio/simulator.py
@@ -229,12 +229,12 @@ class MarketSimulator():
             Rmat[idx, :] = selector(result).values
         Pmat = cvx.Variable((num_sources, len(attr_times)))
         if fit == "linear":
-            prob = cvx.Problem(cvx.Minimize(0), [Wmat * Pmat == Rmat])
+            prob = cvx.Problem(cvx.Minimize(0), [Wmat @ Pmat == Rmat])
             prob.solve()
         elif fit == "least-squares":
-            error = cvx.sum_squares(Wmat * Pmat - Rmat)
+            error = cvx.sum_squares(Wmat @ Pmat - Rmat)
             prob = cvx.Problem(cvx.Minimize(error),
-                               [Pmat.T * weights == true_arr])
+                               [Pmat.T @ weights == true_arr])
             prob.solve()
         else:
             raise Exception("Unknown fitting method.")
@@ -243,8 +243,8 @@ class MarketSimulator():
         data = pd.DataFrame(columns=[s.name for s in alpha_sources],
                             index=attr_times,
                             data=Pmat.value.T * wmask)
-        data['residual'] = true_arr - np.asarray((weights * Pmat).value).ravel()
+        data['residual'] = true_arr - np.asarray((weights @ Pmat).value).ravel()
         data['RMS error'] = np.asarray(
-            cvx.norm(Wmat * Pmat - Rmat, 2, axis=0).value).ravel()
+            cvx.norm(Wmat @ Pmat - Rmat, 2, axis=0).value).ravel()
         data['RMS error'] /= np.sqrt(num_sources)
         return data


### PR DESCRIPTION
Using * for matrix multiplication has been deprecated since CVXPY 1.1.
Use * for matrix-scalar and vector-scalar multiplication.
Use @ for matrix-matrix and matrix-vector multiplication.
Use multiply for elementwise multiplication.

Update all matrix-matrix multiplication using @ to be compatible with latest CVXPY and avoid all warnings in tests

@SteveDiamond pls help review, ty