### PR TITLE
Fix HelloWorld.ipynb to solve Issue #59

### DIFF
--- a/examples/HelloWorld.ipynb
+++ b/examples/HelloWorld.ipynb
@@ -18,7 +18,6 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import numpy as np\n",
     "import pandas as pd\n",
     "import quandl\n",
     "\n",
@@ -257,7 +256,7 @@
    ],
    "source": [
     "r_hat = returns.rolling(window=250, min_periods=250).mean().shift(1).dropna()\n",
-    "Sigma_hat = returns.rolling(window=250, min_periods=250, closed='neither').cov().dropna()\n",
+    "Sigma_hat = returns.rolling(window=250, min_periods=250, closed='neither').cov().dropna().droplevel(1)\n",
     "\n",
     "r_hat.tail()"
    ]


### PR DESCRIPTION
* The `ValueError: Cannot broadcast dimensions (562, 5) (5,)` is caused by the change of utility function values_in_time, it will always treat multi-index dataframe as multi-period prediction, neglecting the case of multi-index [t, symbol]. Therefore we will have to drop symbol index level to make it work.
* remove useless numpy import