### PR TITLE
windows-compatible makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,45 @@
 BUILDDIR      = build
 PYTHON        = python
 ENVDIR        = env
+BINDIR        = $(BINDIR)
 
+ifeq ($(OS), Windows_NT)
+    BINDIR=$(ENVDIR)/Scripts
+endif
 
 .PHONY: env docs clean test cleanenv
-	
+
 env:
 	$(PYTHON) -m venv $(ENVDIR)
-	$(ENVDIR)/bin/python -m pip install -r requirements.txt
-	$(ENVDIR)/bin/python -m pip install --editable .
+	$(BINDIR)/python -m pip install -r requirements.txt
+	$(BINDIR)/python -m pip install --editable .
 	
 test:
-	$(ENVDIR)/bin/python -m unittest cvxportfolio/tests/*.py
+	$(BIN)/python -m unittest cvxportfolio/tests/*.py
 
 clean:
 	-rm -rf $(BUILDDIR)/* 
-	
+
 cleanenv:
 	-rm -rf $(ENVDIR)/*
 
 docs:
-	$(ENVDIR)/bin/sphinx-build -E docs $(BUILDDIR); open build/index.html
-	
+	$(BINDIR)/sphinx-build -E docs $(BUILDDIR); open build/index.html
+
 revision:
-	$(ENVDIR)/bin/python bumpversion.py revision	
+	$(BINDIR)/python bumpversion.py revision	
 	git push
-	$(ENVDIR)/bin/python setup.py sdist bdist_wheel
-	$(ENVDIR)/bin/twine upload --skip-existing dist/*
+	$(BINDIR)/python setup.py sdist bdist_wheel
+	$(BINDIR)/twine upload --skip-existing dist/*
 
 minor:
-	$(ENVDIR)/bin/python bumpversion.py minor	
+	$(BINDIR)/python bumpversion.py minor	
 	git push
-	$(ENVDIR)/bin/python setup.py sdist bdist_wheel
-	$(ENVDIR)/bin/twine upload --skip-existing dist/*
+	$(BINDIR)/python setup.py sdist bdist_wheel
+	$(BINDIR)/twine upload --skip-existing dist/*
 
 major:
-	$(ENVDIR)/bin/python bumpversion.py major	
+	$(BINDIR)/python bumpversion.py major	
 	git push
-	$(ENVDIR)/bin/python setup.py sdist bdist_wheel
-	$(ENVDIR)/bin/twine upload --skip-existing dist/*
+	$(BINDIR)/python setup.py sdist bdist_wheel
+	$(BINDIR)/twine upload --skip-existing dist/*

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILDDIR      = build
 PYTHON        = python
 ENVDIR        = env
-BINDIR        = $(BINDIR)
+BINDIR        = $(ENVDIR)/bin
 
 ifeq ($(OS), Windows_NT)
     BINDIR=$(ENVDIR)/Scripts


### PR DESCRIPTION
makes current `venv`-based makefile windows-compatible.
addresses the issue mentioned in https://github.com/cvxgrp/cvxportfolio/issues/83