### PR TITLE
self.base_location is needed by cache even if no universe

### DIFF
--- a/cvxportfolio/simulator.py
+++ b/cvxportfolio/simulator.py
@@ -387,6 +387,7 @@ class MarketSimulator(Estimator):
             base_location=BASE_LOCATION,
             **kwargs):
         """Initialize the Simulator and download data if necessary."""
+        self.base_location = Path(base_location)
         if not len(universe):
             if ((returns is None) or (volumes is None)):
                 raise SyntaxError(
@@ -405,7 +406,6 @@ class MarketSimulator(Estimator):
         else:
             self.universe = universe
             self.cash_key = cash_key
-            self.base_location = Path(base_location)
             self.prepare_data()
 
         self.round_trades = round_trades


### PR DESCRIPTION
The line below requires self.base_location to be defined even in the no-universe case. Without this fix we get `AttributeError: 'MarketSimulator' object has no attribute 'base_location'`.
https://github.com/cvxgrp/cvxportfolio/blob/5790c42446381c5ca781ffa2cdd4010913d0a412/cvxportfolio/simulator.py#L574