### PR TITLE
make periods_per_year a standardized constant, and correctly implement it for cost calcs

### DIFF
--- a/cvxportfolio/simulator.py
+++ b/cvxportfolio/simulator.py
@@ -148,9 +148,14 @@ class MarketData:
     
     def __init__(self, 
         universe = [], 
-        returns=None, volumes=None, prices=None, 
-        cash_key='USDOLLAR', base_location=BASE_LOCATION, 
-        periods_per_year=PPY, min_history=PPY, max_contiguous_missing='10d',
+        returns=None,
+        volumes=None,
+        prices=None, 
+        cash_key='USDOLLAR',
+        base_location=BASE_LOCATION, 
+        periods_per_year=PPY,
+        min_history=PPY,
+        max_contiguous_missing='10d',
         **kwargs,
     ):
         
@@ -459,7 +464,7 @@ class MarketSimulator:
         cash_key="USDOLLAR",
         base_location=BASE_LOCATION,
         periods_per_year=252,
-        **kwargs
+        **kwargs,
     ):
         """Initialize the Simulator and download data if necessary."""
         self.base_location = Path(base_location)

--- a/cvxportfolio/simulator.py
+++ b/cvxportfolio/simulator.py
@@ -460,10 +460,10 @@ class MarketSimulator:
         round_trades=True,
         # spread_on_lending_cash_percent=.5,
         # spread_on_borrowing_cash_percent=.5,
-        min_history_for_inclusion=252,
+        min_history_for_inclusion=PPY,
         cash_key="USDOLLAR",
         base_location=BASE_LOCATION,
-        periods_per_year=252,
+        periods_per_year=PPY,
         **kwargs,
     ):
         """Initialize the Simulator and download data if necessary."""
@@ -474,7 +474,7 @@ class MarketSimulator:
             universe=universe, returns=returns,
             volumes=volumes, prices=prices,
             cash_key=cash_key, base_location=base_location,
-            periods_per_year=252, **kwargs)
+            periods_per_year=self.periods_per_year, **kwargs)
                 
         # if not len(universe):
         #     if ((returns is None) or (volumes is None)):


### PR DESCRIPTION
My understanding that making the optimizer period-agnostic is on the roadmap, but in the meantime I think it makes sense to support user specified periods_per_year (e.g., 250, 252, and 365). I've made a small change to let one set periods_per_year in the simulator and also corrects the flow-through to the cost calculations.

I'd note that 252 is hard-coded into various tests & other areas in the codebase and it may make sense to make it a "global" constant.