### PR TITLE
fix Fred failing on the second download attempt (new data being empty)

### DIFF
--- a/cvxportfolio/data.py
+++ b/cvxportfolio/data.py
@@ -406,11 +406,13 @@ class FredBase(BaseData):
 
     def download(self, symbol="DFF", current=None):
         if current is None or ((pd.Timestamp.today() - current.index[-1]) > pd.Timedelta('2d')):
-            end = pd.Timestamp.today()
             return self._download(symbol)
         else:
             new = self._download(symbol)
             new = new.loc[new.index > current.index[-1]]
+            if new.empty:
+                return current
+
             assert new.index[0] > current.index[-1]
             return pd.concat([current, new])
 


### PR DESCRIPTION
there is a bug that happens when you try to download Fred rates (which works fine), and download it again (this happens when during `pre_evaluation()` every time a simulator is run).

Because the line `new = new.loc[new.index > current.index[-1]]` would result in an empty dataframe, attempting to index it in the next line (`new.index[0]`) would throw an `IndexError`. The fix makes it simply return the current dataframe (as there is nothing to update).