### PR TITLE
fixing edge case bug for change in universe

### DIFF
--- a/cvxportfolio/result.py
+++ b/cvxportfolio/result.py
@@ -87,6 +87,10 @@ class BacktestResult:
             # this is the default situation with yfinance data
             if self._current_universe.isin(new_universe).all():
                 joined = new_universe
+                # preprend all all the assets from full that are not in joined
+                joined = joined.insert(0, sorted(
+                    set(self._current_full_universe[:-1])
+                    - set(joined)))
 
             # otherwise we lose the ordering :(
             else:


### PR DESCRIPTION
Caught this subtle bug for change in universe. It is necessary to include assets that were in index before in the 'joined' variable to assert that PnL doesn't change.
For example:
start with index composition A, B, C
then A leaves the index -> current_universe = B, C
if D gets in the index -> new_universe = B, C, D and current_universe = B, C -> joined = B, C, D
then in the line self._h.reindex(columns = joined) it ends up dropping column A from _h, which changes NAV for all days that had non zero dollar position in A.