### PR TITLE
Fix UserWarning on matrix multiplication

### DIFF
--- a/cvxportfolio/costs.py
+++ b/cvxportfolio/costs.py
@@ -876,7 +876,7 @@ class TransactionCost(SimulatorCost):
                     ) @ self._second_term_multiplier
             assert expression.is_convex()
         if self.c is not None:
-            expression += cp.sum(z[:-1] * self.c.parameter)
+            expression += z[:-1] @ self.c.parameter
         return expression
 
 # Backward compatibility before 1.2.0


### PR DESCRIPTION
"UserWarning: This use of ``*`` has resulted in matrix multiplication. 
Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1"