### PR TITLE
Validate index of UserProvidedMarketData dataframes (fixes #175)

### DIFF
--- a/cvxportfolio/data/market_data.py
+++ b/cvxportfolio/data/market_data.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from ..errors import DataError
+from ..errors import DataError, UserDataError
 from ..utils import (hash_, make_numeric, periods_per_year_from_datetime_index,
                      resample_returns, set_pd_read_only)
 from . import symbol_data
@@ -472,6 +472,104 @@ class MarketDataInMemory(MarketData):
             raise SyntaxError(
                 'Prices should have same columns as returns, minus cash_key.')
 
+        # Index sanity checks (see issue #175). These catch, at
+        # initialization time, index problems that would otherwise cause
+        # either silent look-ahead bias (non-monotonic index) or an
+        # obscure ``KeyError`` deep inside the back-test loop (missing
+        # timestamps), instead of a clear, actionable error.
+        self._check_index(self.returns.index, 'returns')
+
+        if self.volumes is not None:
+            self._check_index(self.volumes.index, 'volumes')
+            self._check_index_covers(
+                self.returns.index, self.volumes.index, 'returns', 'volumes')
+
+        if self.prices is not None:
+            self._check_index(self.prices.index, 'prices')
+            self._check_index_covers(
+                self.returns.index, self.prices.index, 'returns', 'prices')
+
+    @staticmethod
+    def _check_index(index, name):
+        """Check that a timeseries dataframe's index is well-formed.
+
+        We require the index to be sorted in increasing order and free of
+        duplicated timestamps.
+
+        A non-monotonic index silently breaks the walk-forward logic used
+        at back-test time: internally we select "past data" relative to
+        time :math:`t` by slicing a dataframe up to :math:`t`'s integer
+        position (``.iloc[:tidx]``); if the index is not sorted this
+        slice does not correspond to actual past data, and future data
+        could silently leak into the back-test.
+
+        A duplicated timestamp makes lookups by that timestamp
+        (``pandas.Index.get_loc``) ambiguous (it returns a slice or a
+        boolean mask instead of a single integer position), which then
+        breaks the same slicing logic in a different, equally silent, way.
+
+        :param index: Index to check.
+        :type index: pandas.Index
+        :param name: Name of the dataframe the index belongs to, used
+            only to compose the error message (*e.g.*, ``'returns'``).
+        :type name: str
+
+        :raises cvxportfolio.errors.UserDataError: The index is not
+            monotonic increasing, or has duplicated timestamps.
+        """
+        if not index.is_monotonic_increasing:
+            raise UserDataError(
+                f"The index of the provided `{name}` dataframe is not"
+                " sorted in increasing order. Sort it before passing it"
+                f" in, e.g., with `{name} = {name}.sort_index()`.")
+        if index.has_duplicates:
+            dupes = index[index.duplicated()].unique()
+            raise UserDataError(
+                f"The index of the provided `{name}` dataframe has"
+                f" {len(dupes)} duplicated timestamp(s), for example"
+                f" {dupes[0]}. Each timestamp must appear at most once;"
+                f" de-duplicate `{name}` before passing it in, e.g., with"
+                f" `{name} = {name}[~{name}.index.duplicated()]`.")
+
+    @staticmethod
+    def _check_index_covers(
+            required_index, provided_index, required_name, provided_name):
+        """Check that ``provided_index`` contains all of ``required_index``.
+
+        At serve time we look up the current timestamp independently in
+        each dataframe's own index (via ``pandas.Index.get_loc``). If a
+        timestamp that is present in ``returns`` is missing from
+        ``volumes`` or ``prices``, that lookup fails with an obscure
+        ``KeyError`` raised deep inside the simulation loop, rather than
+        with a clear error at initialization time.
+
+        :param required_index: Index whose timestamps must all be present
+            in ``provided_index`` (typically ``returns.index``).
+        :type required_index: pandas.Index
+        :param provided_index: Index to check against.
+        :type provided_index: pandas.Index
+        :param required_name: Name of the dataframe ``required_index``
+            belongs to, used only for the error message.
+        :type required_name: str
+        :param provided_name: Name of the dataframe ``provided_index``
+            belongs to, used only for the error message.
+        :type provided_name: str
+
+        :raises cvxportfolio.errors.UserDataError: ``provided_index`` is
+            missing one or more timestamps present in ``required_index``.
+        """
+        missing = required_index.difference(provided_index)
+        if len(missing) > 0:
+            raise UserDataError(
+                f"The index of the provided `{provided_name}` dataframe"
+                f" is missing {len(missing)} timestamp(s) that are"
+                f" present in `{required_name}`, for example"
+                f" {missing[0]}. The index of `{provided_name}` must"
+                f" contain (at least) every timestamp present in the"
+                f" index of `{required_name}`, otherwise a raw KeyError"
+                " would be raised while serving data during a"
+                " back-test.")
+
     @property
     def periods_per_year(self):
         """Average trading periods per year inferred from the data.
@@ -500,6 +598,47 @@ class UserProvidedMarketData(MarketDataInMemory):
 
         The new parameter ``universe_selection_in_time`` used to optionally
         exclude assets from the trading universe at different points in time.
+
+    .. note::
+
+        The (datetime) index of ``returns``, ``volumes``, and ``prices`` is
+        validated at initialization time:
+
+        - each of their indexes must be sorted in increasing order and free
+          of duplicated timestamps (a non-monotonic index would silently
+          break the walk-forward slicing logic used at back-test time,
+          potentially leaking future data into the back-test; a duplicated
+          timestamp makes lookups ambiguous);
+        - the index of ``volumes`` and of ``prices`` (whenever provided)
+          must each contain (at least) every timestamp present in the index
+          of ``returns``, otherwise data is served incorrectly (or a raw
+          ``KeyError`` is raised) while back-testing.
+
+        For example, the following raises
+        :class:`cvxportfolio.errors.UserDataError` because the timestamps
+        are not sorted::
+
+            import pandas as pd
+            import cvxportfolio as cvx
+
+            bad_returns = pd.DataFrame(
+                {'AAPL': [0.01, -0.02, 0.005]},
+                index=pd.to_datetime(
+                    ['2024-01-03', '2024-01-02', '2024-01-04']))
+            cvx.UserProvidedMarketData(
+                returns=bad_returns, cash_key='cash',
+                min_history=pd.Timedelta('0d'))
+            # raises UserDataError: "The index of the provided `returns`
+            # dataframe is not sorted in increasing order. [...]"
+
+        The fix is simply to sort your dataframes by their index (and drop
+        duplicated timestamps, if any) before passing them in::
+
+            good_returns = bad_returns.sort_index()
+            good_returns = good_returns[~good_returns.index.duplicated()]
+            cvx.UserProvidedMarketData(
+                returns=good_returns, cash_key='cash',
+                min_history=pd.Timedelta('0d')) # no error
 
     :param returns: Historical open-to-open returns. The return
         at time :math:`t` is :math:`r_t = p_{t+1}/p_t -1` where

--- a/cvxportfolio/tests/test_data.py
+++ b/cvxportfolio/tests/test_data.py
@@ -29,7 +29,7 @@ from cvxportfolio.data import (DownloadedMarketData, Fred,
                                UserProvidedMarketData, YahooFinance,
                                _loader_csv, _loader_pickle, _loader_sqlite,
                                _storer_csv, _storer_pickle, _storer_sqlite)
-from cvxportfolio.errors import DataError
+from cvxportfolio.errors import DataError, UserDataError
 from cvxportfolio.tests import CvxportfolioTest
 
 
@@ -1191,6 +1191,89 @@ class TestMarketData(CvxportfolioTest):
                 min_history=pd.Timedelta('60d'),
                 # has also cash
                 universe_selection_in_time=pd.DataFrame(self.returns))
+
+    def test_user_provided_market_data_bad_index(self):
+        """Test UserProvidedMarketData input validation of dataframe index.
+
+        See github.com/cvxgrp/cvxportfolio issue #175: before this test
+        (and the corresponding fix) none of these cases were caught, and
+        would either silently corrupt back-test results (non-monotonic
+        index causing look-ahead, ambiguous lookups from a duplicated
+        index) or fail later with an obscure raw ``KeyError`` deep inside
+        the back-test loop (misaligned ``volumes``/``prices`` index),
+        instead of a clear error raised at initialization time.
+        """
+        returns = pd.DataFrame(
+            {'A': [0.01, -0.02, 0.03, 0.0], 'USDOLLAR': [0., 0., 0., 0.]},
+            index=pd.to_datetime(
+                ['2024-01-02', '2024-01-03', '2024-01-04', '2024-01-05']))
+        volumes = pd.DataFrame(
+            {'A': [100., 200., 300., 400.]}, index=returns.index)
+        prices = pd.DataFrame(
+            {'A': [10., 11., 12., 13.]}, index=returns.index)
+
+        # sanity check: the well-formed inputs above don't raise
+        _ = UserProvidedMarketData(
+            returns=returns, volumes=volumes, prices=prices,
+            cash_key='USDOLLAR', min_history=pd.Timedelta('0d'))
+
+        # 1) non-monotonic (unsorted) returns index
+        shuffled_returns = returns.iloc[[0, 2, 1, 3]]
+        with self.assertRaises(UserDataError):
+            UserProvidedMarketData(
+                returns=shuffled_returns, volumes=volumes, prices=prices,
+                cash_key='USDOLLAR', min_history=pd.Timedelta('0d'))
+
+        # non-monotonic volumes index (returns is fine)
+        shuffled_volumes = volumes.iloc[[0, 2, 1, 3]]
+        with self.assertRaises(UserDataError):
+            UserProvidedMarketData(
+                returns=returns, volumes=shuffled_volumes, prices=prices,
+                cash_key='USDOLLAR', min_history=pd.Timedelta('0d'))
+
+        # 2) duplicated timestamp in the returns index
+        dup_index = pd.to_datetime(
+            ['2024-01-02', '2024-01-02', '2024-01-04', '2024-01-05'])
+        dup_returns = pd.DataFrame(returns.values, index=dup_index,
+                                    columns=returns.columns)
+        with self.assertRaises(UserDataError):
+            UserProvidedMarketData(
+                returns=dup_returns, volumes=volumes, prices=prices,
+                cash_key='USDOLLAR', min_history=pd.Timedelta('0d'))
+
+        # duplicated timestamp in the prices index (returns is fine)
+        dup_prices = pd.DataFrame(prices.values, index=dup_index,
+                                   columns=prices.columns)
+        with self.assertRaises(UserDataError):
+            UserProvidedMarketData(
+                returns=returns, volumes=volumes, prices=dup_prices,
+                cash_key='USDOLLAR', min_history=pd.Timedelta('0d'))
+
+        # 3) volumes index missing a timestamp present in returns
+        misaligned_volumes = volumes.drop(volumes.index[2])
+        with self.assertRaises(UserDataError):
+            UserProvidedMarketData(
+                returns=returns, volumes=misaligned_volumes, prices=prices,
+                cash_key='USDOLLAR', min_history=pd.Timedelta('0d'))
+
+        # prices index missing a timestamp present in returns
+        misaligned_prices = prices.drop(prices.index[0])
+        with self.assertRaises(UserDataError):
+            UserProvidedMarketData(
+                returns=returns, volumes=volumes, prices=misaligned_prices,
+                cash_key='USDOLLAR', min_history=pd.Timedelta('0d'))
+
+        # volumes/prices with a *superset* of the returns' timestamps is
+        # fine (this mirrors the existing test data, whose volumes.csv
+        # has one extra day of history before returns.csv starts)
+        extra_ts = pd.DatetimeIndex(
+            ['2024-01-01']).append(volumes.index)
+        superset_volumes = pd.DataFrame(
+            [[50.]] + volumes.values.tolist(), index=extra_ts,
+            columns=volumes.columns)
+        _ = UserProvidedMarketData(
+            returns=returns, volumes=superset_volumes, prices=prices,
+            cash_key='USDOLLAR', min_history=pd.Timedelta('0d'))
 
     def test_market_data_full(self):
         """Test serve method of DownloadedMarketData."""

--- a/cvxportfolio/tests/test_simulator.py
+++ b/cvxportfolio/tests/test_simulator.py
@@ -181,7 +181,9 @@ class TestSimulator(CvxportfolioTest):
             returns=pd.DataFrame([[0., 0.]], columns=['A', 'USDOLLAR'],
               index=[pd.Timestamp('2020-01-01'), pd.Timestamp('2021-01-01')]),
             volumes=pd.DataFrame(
-            [[0.]], columns=['A']), round_trades=False,
+            [[0.], [0.]], columns=['A'],
+            index=[pd.Timestamp('2020-01-01'), pd.Timestamp('2021-01-01')]),
+            round_trades=False,
             min_history = pd.Timedelta('0d'))
 
         with self.assertRaises(SyntaxError):


### PR DESCRIPTION
Fixes #175 (and relates to #173).

## The gap

`UserProvidedMarketData._check_sizes` only compares the *column* shapes of
`returns`/`volumes`/`prices`. Nothing checks their (datetime) **index**:
not monotonicity, not duplicates, not alignment across the three
dataframes. I confirmed there is currently no `is_monotonic`,
`duplicated`, or `index.equals` anywhere in `market_data.py`.

This matters because `MarketDataInMemory.serve(t)` looks up `t`
independently in each dataframe's own index and then slices "up to that
position" with `.iloc[:tidx]` to build `past_returns`/`past_volumes`:

```python
tidx = self.returns.index.get_loc(t)
past_returns = ...iloc[:tidx]
...
tidx = self.volumes.index.get_loc(t)
past_volumes = ...iloc[:tidx]
```

If the index isn't sorted, `.iloc[:tidx]` no longer means "everything
before `t`" — it can silently include rows that are chronologically
*after* `t`, which is a look-ahead bug in a walk-forward back-tester. A
duplicated timestamp makes `get_loc` return a slice/mask instead of a
single position, breaking the same logic in a different, equally silent,
way. And if a timestamp present in `returns` is missing from `volumes` or
`prices`, `get_loc` raises a bare `KeyError` from deep inside the
back-test loop, with no indication of which dataframe or timestamp is at
fault.

None of this is currently validated, so bad input passes silently into a
simulation and produces a plausible-looking, but wrong, result.

## The fix

Added two helper methods on `MarketDataInMemory`, called from the
existing `_check_sizes` (so they run for both `UserProvidedMarketData`
and `DownloadedMarketData`):

- `_check_index(index, name)` — raises `UserDataError` if the index is
  not monotonic increasing, or has duplicated timestamps.
- `_check_index_covers(required_index, provided_index, ...)` — raises
  `UserDataError` if `provided_index` (volumes'/prices') is missing any
  timestamp present in `required_index` (returns').

I deliberately used a "covers" (superset-allowed) check rather than exact
equality for volumes/prices vs. returns: `volumes`/`prices` having *extra*
history that `returns` doesn't (e.g. one extra earlier day) doesn't break
`serve()`'s per-dataframe date-aware slicing, and this is exactly the
shape of the repo's own `cvxportfolio/tests/volumes.csv` (it has one more
row than `returns.csv`). Requiring exact equality would have broken that
existing fixture for no real safety benefit; requiring only "no missing
timestamps" catches the actual failure mode (`KeyError`/misalignment)
without being needlessly strict.

I used `UserDataError` (`errors.py`, already a subclass of both
`DataError` and `SyntaxError` — "Exception for errors in data provided
by the user") since it's the existing error type built for exactly this
case, and used already for the same kind of purpose in `policies.py`; it
stays compatible with any pre-existing `assertRaises(SyntaxError)` /
`assertRaises(DataError)` call site.

I left `_validate_user_provided_returns`'s NaN-structure check as a
warning (not converted to a raise): the docstring already explains that
mid-history NaNs can be a legitimate delisting/IPO pattern and points
users at `universe_selection_in_time`, so hardening that into an error
felt like a separate, more debatable behavioral change outside the scope
of this fix. Happy to also address it here if you'd rather have it in the
same PR.

Also documented the new validation with a runnable example in
`UserProvidedMarketData`'s docstring, per your comment on #175 asking for
"a detailed script".

## Tests

Added `test_user_provided_market_data_bad_index` in
`cvxportfolio/tests/test_data.py`, covering:
- non-monotonic `returns` index and non-monotonic `volumes` index,
- a duplicated timestamp in `returns` and in `prices`,
- `volumes`/`prices` missing a timestamp present in `returns`,
- and a sanity check that a `volumes` index that is a strict *superset*
  of `returns`' timestamps is still accepted (matching the existing
  `volumes.csv`/`returns.csv` fixture shape).

While running the full suite I found the new check catches a real bug in
`test_simulator_raises`'s last "not raises" case: it passed a `volumes`
dataframe with a default `RangeIndex` (unrelated to `returns`' datetime
index) and asserted that was valid input. I fixed that test case to use a
`volumes` dataframe with a matching datetime index, which is what the
test's own comment ("not raises") already intended to check.

## Test/lint results (Python 3.12.12, pandas 2.2.3, cvxpy 1.5.3 — matching
the CI pins for py3.12)

```
python -m cvxportfolio.tests --ignore-download-errors
Ran 183 tests, 0 failures, 0 errors (1 pre-existing, unrelated
"unexpected success" on test_no_internet, present on a clean checkout of
master too — a NoInternet()-mocking flake in this network environment,
not touched by this change)

python -m pylint cvxportfolio/data/market_data.py
Your code has been rated at 9.96/10 (identical to master; the one
pre-existing W0613 warning at line 273 is untouched by this diff)

python -m pylint cvxportfolio/tests/test_data.py cvxportfolio/tests/test_simulator.py
Your code has been rated at 10.00/10
```
